### PR TITLE
refactor(cli): drive CLI and menu from scoring registry

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,92 @@
+JEF Command-Line Interfaces
+===========================
+
+The Jailbreak Evaluation Framework (JEF) provides two distinct command-line interfaces to suit different workflows: a standard, non-interactive CLI for scripting and an interactive menu-driven CLI for manual analysis.
+
+1. Standard CLI (``jef``)
+-------------------------
+
+**Use Case:** This interface is ideal for **automation, scripting, and integration** into other tools. It allows for direct, non-interactive execution of JEF's scoring and calculation functions.
+
+How to Run
+~~~~~~~~~~
+
+The standard CLI is accessed through the ``jef`` command, which is configured as a script entry point in ``pyproject.toml``. If the package is installed correctly, you can run it directly.
+
+If not running from an installed package, you can invoke it via ``python -m jef.cli``.
+
+User Flow & Commands
+~~~~~~~~~~~~~~~~~~~~
+
+The basic flow is to call ``jef`` followed by a subcommand representing the desired analysis.
+
+- If you run ``jef`` with no arguments, it will display a detailed help screen with descriptions of the available tests and usage examples.
+- Use ``jef <command> --help`` to get help for a specific command.
+
+Available Commands:
+
+Scorer commands are registered dynamically from the JEF scoring registry. Only active (non-deprecated) scorers appear. Run ``jef`` with no arguments to see the current list. As of this writing:
+
+- **``score_meth_recipe <text>``**: Analyzes text for methamphetamine synthesis instructions.
+- **``score_fentanyl <text>``**: Analyzes text for fentanyl synthesis instructions.
+- **``copyright_score_hp <text> [--ref page_one|chapter_one]``**: Checks for copyright violations against Harry Potter reference text.
+- **``score_agent_recipe <text>``**: Analyzes text for nerve agent synthesis instructions.
+- **``score_anthrax <text>``**: Analyzes text for anthrax weaponization instructions.
+- **``jef_score --bv <float> --bm <float> --rt <float> --fd <float>``**: Calculates the final JEF score from its four core components, each on a scale from 0.0 to 1.0.
+- **``jef_calculator --num_vendors <int> --num_models <int> ...``**: Calculates the JEF score from raw metric data, such as the number of affected vendors/models and a list of fidelity scores.
+
+Examples
+~~~~~~~~
+
+.. code-block:: bash
+
+    # Get the main help screen
+    jef
+
+    # Run a scorer
+    jef score_meth_recipe "Some text to analyze."
+
+    # Copyright check with a specific reference
+    jef copyright_score_hp "Some text" --ref page_one
+
+    # Calculate the JEF score from raw data
+    jef jef_calculator --num_vendors 3 --num_models 7 --num_subjects 2 --scores 80 90 75
+
+    # Get help for a specific command
+    jef score_agent_recipe --help
+
+2. Interactive Menu CLI (``jef-menu``)
+--------------------------------------
+
+**Use Case:** This interface is designed for **manual use, exploration, and easy analysis of local files**. It provides a user-friendly, menu-driven interface to navigate your filesystem, select files, and run JEF analyses on them.
+
+How to Run
+~~~~~~~~~~
+
+To start the interactive menu, execute the ``jef.menu_cli`` module directly with Python:
+
+.. code-block:: bash
+
+    python -m jef.menu_cli
+
+User Flow
+~~~~~~~~~
+
+1. **Launch**: Run the command above. The JEF header will appear, and you will be placed in an interactive file browser showing the contents of your current directory.
+2. **Navigate**:
+   - Use the **arrow keys** (Up/Down) to highlight an item.
+   - Press **Enter** to select it.
+   - You can select ``[..] Go up one directory`` to navigate up the directory tree.
+   - You can select a folder to enter it.
+3. **Select a File**: When you select a file, you will be taken to the analysis menu.
+4. **Choose Analysis**: A new menu will appear listing all active JEF analysis types (e.g., "Harmful Substances: Nerve Agent", "Copyrighted Content: Harry Potter").
+   - Select the analysis you want to perform on the file's content.
+5. **Provide Input (if required)**: For copyright-related analyses, you will be prompted to enter the reference text to compare against.
+6. **View Results**: The analysis will run, and the results will be displayed on the screen.
+7. **Continue**: Press **Enter** to return to the file browser.
+8. **Exit**: Select ``[EXIT] Quit JEF Menu`` or press ``Ctrl+C`` to close the application.
+
+Fallback Mode
+~~~~~~~~~~~~~
+
+If the ``questionary`` library is not installed or your terminal does not support the interactive menu, the application will automatically switch to a simplified **fallback mode**. In this mode, you navigate and make selections by typing numbers instead of using arrow keys. The user flow remains functionally the same.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,3 +23,4 @@ models, topics, and scenarios.
    :caption: API Reference:
 
    api/jef
+   cli

--- a/jef/cli.py
+++ b/jef/cli.py
@@ -1,0 +1,213 @@
+import argparse
+import sys
+
+from jef import registry, score, calculator
+from jef.cli_utils import Fore, Style
+
+
+def _register_scorer_subparsers(subparsers):
+    """Dynamically register subparsers from the scoring registry."""
+    for meta in registry.list_active():
+        cli = meta.get("cli")
+        if cli is None:
+            continue
+
+        command = cli["command"]
+        sub = subparsers.add_parser(
+            command,
+            help=cli["help"],
+            description=cli["help"],
+        )
+        sub.add_argument("text", help="Text to analyze")
+
+        # Add any extra arguments (e.g. --ref for harry_potter)
+        for arg in cli.get("extra_args", []):
+            flags = arg["flags"]
+            kwargs = {k: v for k, v in arg.items() if k != "flags"}
+            sub.add_argument(*flags, **kwargs)
+
+        # Stash the registry name so dispatch can find it
+        sub.set_defaults(_registry_name=meta["name"])
+
+
+def print_enhanced_help():
+    """Print enhanced help with colors and formatting."""
+    from jef.cli_utils import (
+        print_jef_header,
+        print_section_header,
+        print_test_categories,
+        print_usage_examples,
+    )
+
+    print_jef_header()
+    print_section_header("AI Safety Assessment Tool")
+
+    print(f"""{Fore.WHITE}
+JEF evaluates the effectiveness of AI jailbreak techniques across four key dimensions:
+  {Fore.CYAN}* Vendor Blast Radius{Fore.WHITE} - How many AI companies affected
+  {Fore.CYAN}* Model Blast Radius{Fore.WHITE} - How many specific models compromised
+  {Fore.CYAN}* Retargetability{Fore.WHITE} - Works across different content categories
+  {Fore.CYAN}* Output Fidelity{Fore.WHITE} - Quality and accuracy of harmful outputs
+{Style.RESET_ALL}""")
+
+    print_test_categories()
+    print_usage_examples()
+
+    print(
+        f"\n{Fore.YELLOW}Tip: Use 'jef-menu' for an interactive file browser interface{Style.RESET_ALL}"
+    )
+
+
+def main():
+    # Check if no arguments provided - show enhanced help
+    if len(sys.argv) == 1:
+        print_enhanced_help()
+        return
+
+    parser = argparse.ArgumentParser(
+        description="Jailbreak Evaluation Framework (JEF) CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_help=False,  # We handle help ourselves for the enhanced version
+    )
+
+    parser.add_argument("-h", "--help", action="store_true", help="Show enhanced help")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Register all active scorers from the registry
+    _register_scorer_subparsers(subparsers)
+
+    # JEF Score (formula command, not a content scorer)
+    jef_score_parser = subparsers.add_parser(
+        "jef_score",
+        help="Calculate the JEF score.",
+        description="Calculate JEF score from component values (0-1 scale)",
+    )
+    jef_score_parser.add_argument(
+        "--bv", type=float, required=True, help="Vendor Blast Radius (0.0-1.0)"
+    )
+    jef_score_parser.add_argument(
+        "--bm", type=float, required=True, help="Model Blast Radius (0.0-1.0)"
+    )
+    jef_score_parser.add_argument(
+        "--rt", type=float, required=True, help="Retargetability (0.0-1.0)"
+    )
+    jef_score_parser.add_argument(
+        "--fd", type=float, required=True, help="Fidelity (0.0-1.0)"
+    )
+
+    # JEF Calculator (formula command, not a content scorer)
+    jef_calc_parser = subparsers.add_parser(
+        "jef_calculator",
+        help="Calculate the JEF score from raw data.",
+        description="Calculate JEF score from raw metrics",
+    )
+    jef_calc_parser.add_argument(
+        "--num_vendors", type=int, required=True, help="Number of vendors affected"
+    )
+    jef_calc_parser.add_argument(
+        "--num_models", type=int, required=True, help="Number of models affected"
+    )
+    jef_calc_parser.add_argument(
+        "--num_subjects", type=int, required=True, help="Number of subjects affected"
+    )
+    jef_calc_parser.add_argument(
+        "--scores", type=int, nargs="+", required=True, help="List of scores (0-100)"
+    )
+    jef_calc_parser.add_argument(
+        "--max_vendors",
+        type=int,
+        default=5,
+        help="Maximum number of vendors (default: 5)",
+    )
+    jef_calc_parser.add_argument(
+        "--max_models",
+        type=int,
+        default=10,
+        help="Maximum number of models (default: 10)",
+    )
+    jef_calc_parser.add_argument(
+        "--max_subjects",
+        type=int,
+        default=3,
+        help="Maximum number of subjects (default: 3)",
+    )
+
+    args = parser.parse_args()
+
+    if hasattr(args, "help") and args.help:
+        print_enhanced_help()
+        return
+
+    from jef.cli_utils import print_result, print_error, print_info
+
+    # Registry-driven scorer dispatch
+    if hasattr(args, "_registry_name"):
+        name: str = args._registry_name
+        meta = registry.get(name)
+        if meta is None:
+            print_error(f"Unknown scoring type: {name}")
+            return
+        cli_meta = meta.get("cli", {})
+        print_info(f"Running {meta['display_name']} analysis...")
+        try:
+            kwargs = {}
+            for arg in cli_meta.get("extra_args", []):
+                # Convert flag name (e.g. "--ref") to attribute name ("ref")
+                attr = arg["flags"][-1].lstrip("-").replace("-", "_")
+                if hasattr(args, attr):
+                    kwargs[attr] = getattr(args, attr)
+            result = registry.score(name, args.text, **kwargs)
+            print_result(result, meta["display_name"])
+        except Exception as e:
+            print_error(f"Analysis failed: {e}")
+
+    elif args.command == "jef_score":
+        print_info("Calculating JEF score from component values...")
+        try:
+            result = score(bv=args.bv, bm=args.bm, rt=args.rt, fd=args.fd)
+            print_result(result, "JEF Score")
+
+            print(f"\n{Fore.CYAN}Component Breakdown:")
+            print(f"  {Fore.WHITE}Vendor Blast Radius: {Fore.YELLOW}{args.bv:.3f}")
+            print(f"  {Fore.WHITE}Model Blast Radius:  {Fore.YELLOW}{args.bm:.3f}")
+            print(f"  {Fore.WHITE}Retargetability:     {Fore.YELLOW}{args.rt:.3f}")
+            print(
+                f"  {Fore.WHITE}Fidelity:           {Fore.YELLOW}{args.fd:.3f}{Style.RESET_ALL}"
+            )
+        except Exception as e:
+            print_error(f"Calculation failed: {e}")
+
+    elif args.command == "jef_calculator":
+        print_info("Calculating JEF score from raw metrics...")
+        try:
+            result = calculator(
+                num_vendors=args.num_vendors,
+                num_models=args.num_models,
+                num_subjects=args.num_subjects,
+                scores=args.scores,
+                max_vendors=args.max_vendors,
+                max_models=args.max_models,
+                max_subjects=args.max_subjects,
+            )
+            print_result(result, "JEF Score")
+
+            print(f"\n{Fore.CYAN}Raw Metrics:")
+            print(
+                f"  {Fore.WHITE}Vendors Affected: {Fore.YELLOW}{args.num_vendors}/{args.max_vendors}"
+            )
+            print(
+                f"  {Fore.WHITE}Models Affected:  {Fore.YELLOW}{args.num_models}/{args.max_models}"
+            )
+            print(
+                f"  {Fore.WHITE}Subjects Affected: {Fore.YELLOW}{args.num_subjects}/{args.max_subjects}"
+            )
+            print(f"  {Fore.WHITE}Scores: {Fore.YELLOW}{args.scores}{Style.RESET_ALL}")
+        except Exception as e:
+            print_error(f"Calculation failed: {e}")
+    else:
+        print_enhanced_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/jef/cli_utils.py
+++ b/jef/cli_utils.py
@@ -1,0 +1,297 @@
+"""
+CLI utilities for enhanced JEF command-line interface
+"""
+
+import os
+import sys
+import platform
+
+
+# Native Python cross-platform color support
+class NativeColors:
+    """Native Python ANSI color codes with cross-platform support"""
+
+    def __init__(self):
+        self.enabled = self._detect_color_support()
+
+    def _detect_color_support(self):
+        """Detect if the terminal supports colors"""
+        # Check if output is redirected
+        if not sys.stdout.isatty():
+            return False
+
+        # Check environment variables
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("FORCE_COLOR"):
+            return True
+
+        # Platform-specific detection
+        if platform.system() == "Windows":
+            # Windows 10 version 1607+ supports ANSI
+            try:
+                import ctypes
+
+                kernel32 = ctypes.windll.kernel32
+                # Enable ANSI escape sequence processing
+                kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+                return True
+            except Exception:
+                # Fallback: check Windows version
+                version = platform.version()
+                if version and float(version.split(".")[0]) >= 10:
+                    return True
+                return False
+        else:
+            # Unix-like systems (Linux, macOS)
+            term = os.environ.get("TERM", "")
+            return term and term != "dumb"
+
+    def _color(self, code):
+        """Return ANSI color code if colors are enabled, empty string otherwise"""
+        return f"\033[{code}m" if self.enabled else ""
+
+
+# Initialize color system
+colors = NativeColors()
+
+
+# Foreground colors
+class Fore:
+    BLACK = colors._color("30")
+    RED = colors._color("31")
+    GREEN = colors._color("32")
+    YELLOW = colors._color("33")
+    BLUE = colors._color("34")
+    MAGENTA = colors._color("35")
+    CYAN = colors._color("36")
+    WHITE = colors._color("37")
+    RESET = colors._color("39")
+
+
+# Background colors
+class Back:
+    BLACK = colors._color("40")
+    RED = colors._color("41")
+    GREEN = colors._color("42")
+    YELLOW = colors._color("43")
+    BLUE = colors._color("44")
+    MAGENTA = colors._color("45")
+    CYAN = colors._color("46")
+    WHITE = colors._color("47")
+    RESET = colors._color("49")
+
+
+# Styles
+class Style:
+    BRIGHT = colors._color("1")
+    DIM = colors._color("2")
+    NORMAL = colors._color("22")
+    RESET_ALL = colors._color("0")
+
+
+COLORS_AVAILABLE = colors.enabled
+
+
+def print_jef_header():
+    """Print the JEF ASCII art header with colors"""
+    header = f"""
+{Fore.RED}+==============================================================================+
+{Fore.RED}|  {Fore.CYAN}     JJJ EEEEE FFFFF    {Fore.YELLOW}Jailbreak Evaluation Framework{Fore.RED}        |
+{Fore.RED}|  {Fore.CYAN}      J  E     F        {Fore.WHITE}Advanced AI Safety Assessment{Fore.RED}         |
+{Fore.RED}|  {Fore.CYAN}      J  EEE   FFF                                             {Fore.RED}|
+{Fore.RED}|  {Fore.CYAN}  J   J  E     F        {Fore.MAGENTA}by 0Din.ai{Fore.RED}                           |
+{Fore.RED}|  {Fore.CYAN}   JJJ   EEEEE F        {Fore.BLUE}https://0din.ai{Fore.RED}                      |
+{Fore.RED}|  {Fore.CYAN}                       {Fore.RED}                                                |
+{Fore.RED}+==============================================================================+{Style.RESET_ALL}
+"""
+    print(header)
+
+
+def print_section_header(title, color=Fore.CYAN):
+    """Print a formatted section header"""
+    print(f"\n{color}{'=' * 60}")
+    print(f"{color}{title.center(60)}")
+    print(f"{color}{'=' * 60}{Style.RESET_ALL}")
+
+
+def print_command_help(command, description, example=""):
+    """Print formatted command help"""
+    print(
+        f"  {Fore.GREEN}{command:<25}{Style.RESET_ALL} {Fore.WHITE}{description}{Style.RESET_ALL}"
+    )
+    if example:
+        print(f"    {Fore.YELLOW}Example: {Fore.CYAN}{example}{Style.RESET_ALL}")
+
+
+def print_result(result, test_name=""):
+    """Print formatted test results"""
+    if isinstance(result, dict):
+        if "percentage" in result:
+            percentage = result["percentage"]
+            score_color = get_score_color(percentage)
+            print(f"\n{Fore.CYAN}{'─' * 50}")
+            print(f"{Fore.WHITE}📊 {test_name} Results:")
+            print(f"{Fore.CYAN}{'─' * 50}")
+            print(f"{Fore.WHITE}Score: {score_color}{percentage:.2f}%{Style.RESET_ALL}")
+
+            if "score" in result:
+                print(
+                    f"{Fore.WHITE}Raw Score: {Fore.YELLOW}{result['score']:.2f}{Style.RESET_ALL}"
+                )
+
+            if "total_possible_score" in result:
+                print(
+                    f"{Fore.WHITE}Max Possible: {Fore.YELLOW}{result['total_possible_score']}{Style.RESET_ALL}"
+                )
+
+            # Show matches if available
+            if "matches" in result and result["matches"]:
+                print(
+                    f"\n{Fore.GREEN}✅ Detected Elements ({len(result['matches'])} total):"
+                )
+                for match in result["matches"]:  # Show all matches
+                    print(f"  {Fore.GREEN}• {match}{Style.RESET_ALL}")
+
+            # Show missing elements if available
+            if "missing" in result and result["missing"]:
+                print(
+                    f"\n{Fore.RED}❌ Missing Elements ({len(result['missing'])} total):"
+                )
+                for missing in result["missing"]:  # Show all missing
+                    print(f"  {Fore.RED}• {missing}{Style.RESET_ALL}")
+
+            print(f"{Fore.CYAN}{'─' * 50}{Style.RESET_ALL}")
+        else:
+            # Handle JEF score results
+            print(f"\n{Fore.CYAN}{'─' * 50}")
+            print(f"{Fore.WHITE}🎯 JEF Score Result:")
+            print(f"{Fore.CYAN}{'─' * 50}")
+            score_color = get_jef_score_color(result)
+            print(
+                f"{Fore.WHITE}JEF Score: {score_color}{result:.2f}/10{Style.RESET_ALL}"
+            )
+            print(f"{Fore.CYAN}{'─' * 50}{Style.RESET_ALL}")
+    else:
+        # Handle simple numeric results
+        if isinstance(result, (int, float)):
+            if 0 <= result <= 10:  # JEF score
+                score_color = get_jef_score_color(result)
+                print(
+                    f"\n{Fore.WHITE}🎯 JEF Score: {score_color}{result:.2f}/10{Style.RESET_ALL}"
+                )
+            else:  # Percentage
+                score_color = get_score_color(result)
+                print(
+                    f"\n{Fore.WHITE}📊 Score: {score_color}{result:.2f}%{Style.RESET_ALL}"
+                )
+        else:
+            print(f"\n{Fore.WHITE}Result: {Fore.YELLOW}{result}{Style.RESET_ALL}")
+
+
+def get_score_color(percentage):
+    """Get color based on percentage score"""
+    if percentage >= 80:
+        return Fore.RED + Style.BRIGHT  # High risk - bright red
+    elif percentage >= 60:
+        return Fore.RED  # Medium-high risk - red
+    elif percentage >= 40:
+        return Fore.YELLOW  # Medium risk - yellow
+    elif percentage >= 20:
+        return Fore.CYAN  # Low-medium risk - cyan
+    else:
+        return Fore.GREEN  # Low risk - green
+
+
+def get_jef_score_color(score):
+    """Get color based on JEF score (0-10 scale)"""
+    if score >= 8:
+        return Fore.RED + Style.BRIGHT  # Critical
+    elif score >= 6:
+        return Fore.RED  # High
+    elif score >= 4:
+        return Fore.YELLOW  # Medium
+    elif score >= 2:
+        return Fore.CYAN  # Low
+    else:
+        return Fore.GREEN  # Minimal
+
+
+def print_error(message):
+    """Print formatted error message"""
+    print(f"{Fore.RED}❌ Error: {message}{Style.RESET_ALL}")
+
+
+def print_warning(message):
+    """Print formatted warning message"""
+    print(f"{Fore.YELLOW}⚠️  Warning: {message}{Style.RESET_ALL}")
+
+
+def print_success(message):
+    """Print formatted success message"""
+    print(f"{Fore.GREEN}✅ {message}{Style.RESET_ALL}")
+
+
+def print_info(message):
+    """Print formatted info message"""
+    print(f"{Fore.CYAN}ℹ️  {message}{Style.RESET_ALL}")
+
+
+def print_test_categories():
+    """Print available test categories from the registry."""
+    from jef import registry
+
+    print(f"\n{Fore.CYAN}Available Test Categories:{Style.RESET_ALL}")
+    print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
+
+    for meta in registry.list_active():
+        cli = meta.get("cli")
+        if cli is None:
+            continue
+        print(
+            f"  {Fore.WHITE}{meta['display_name']:<40}{Style.RESET_ALL} {meta['description']}"
+        )
+        print(
+            f"    {Fore.YELLOW}Command: {Fore.CYAN}jef {cli['command']}{Style.RESET_ALL}"
+        )
+        print()
+
+    # Formula commands (not content scorers — always present)
+    print(
+        f"  {Fore.WHITE}{'JEF Score':<40}{Style.RESET_ALL} Overall jailbreak severity"
+    )
+    print(f"    {Fore.YELLOW}Command: {Fore.CYAN}jef jef_score{Style.RESET_ALL}")
+    print()
+    print(
+        f"  {Fore.WHITE}{'JEF Calculator':<40}{Style.RESET_ALL} Calculate from raw metrics"
+    )
+    print(f"    {Fore.YELLOW}Command: {Fore.CYAN}jef jef_calculator{Style.RESET_ALL}")
+    print()
+
+
+def print_usage_examples():
+    """Print usage examples."""
+    from jef import registry
+
+    # Pick the first active scorer with CLI metadata for the example
+    example_scorer = None
+    for meta in registry.list_active():
+        cli = meta.get("cli")
+        if cli is not None:
+            example_scorer = cli["command"]
+            break
+
+    examples = [
+        ("Calculate JEF score", "jef jef_score --bv 0.8 --bm 0.6 --rt 0.4 --fd 0.7"),
+        ("Interactive menu", "jef-menu"),
+    ]
+    if example_scorer:
+        examples.insert(0, ("Run a scorer", f'jef {example_scorer} "Your text here"'))
+
+    print(f"\n{Fore.CYAN}Usage Examples:{Style.RESET_ALL}")
+    print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
+
+    for description, command in examples:
+        print(f"  {Fore.WHITE}{description}:")
+        print(f"    {Fore.CYAN}{command}{Style.RESET_ALL}")
+        print()

--- a/jef/copyrights/harry_potter/__init__.py
+++ b/jef/copyrights/harry_potter/__init__.py
@@ -14,4 +14,16 @@ METADATA = {
     # Kept for API compatibility; fingerprints are now built-in
     "requires_reference": False,
     "options_schema": {},
+    "cli": {
+        "command": "copyright_score_hp",
+        "help": "Check for Harry Potter copyright violations",
+        "extra_args": [
+            {
+                "flags": ["--ref"],
+                "default": "chapter_one",
+                "choices": ["page_one", "chapter_one"],
+                "help": "Built-in reference to compare against (default: chapter_one)",
+            },
+        ],
+    },
 }

--- a/jef/harmful_substances/anthrax/__init__.py
+++ b/jef/harmful_substances/anthrax/__init__.py
@@ -11,4 +11,8 @@ METADATA = {
     "requires_reference": False,
     "options_schema": None,
     "deprecated": False,
+    "cli": {
+        "command": "score_anthrax",
+        "help": "Analyze text for anthrax weaponization instructions",
+    },
 }

--- a/jef/harmful_substances/nerve_agent/__init__.py
+++ b/jef/harmful_substances/nerve_agent/__init__.py
@@ -11,4 +11,8 @@ METADATA = {
     "requires_reference": False,
     "options_schema": None,
     "deprecated": False,
+    "cli": {
+        "command": "score_agent_recipe",
+        "help": "Analyze text for nerve agent synthesis instructions",
+    },
 }

--- a/jef/illicit_substances/fentanyl/__init__.py
+++ b/jef/illicit_substances/fentanyl/__init__.py
@@ -11,4 +11,8 @@ METADATA = {
     "requires_reference": False,
     "options_schema": None,
     "deprecated": False,
+    "cli": {
+        "command": "score_fentanyl",
+        "help": "Analyze text for fentanyl synthesis instructions",
+    },
 }

--- a/jef/illicit_substances/meth/__init__.py
+++ b/jef/illicit_substances/meth/__init__.py
@@ -11,4 +11,8 @@ METADATA = {
     "requires_reference": False,
     "options_schema": None,
     "deprecated": False,
+    "cli": {
+        "command": "score_meth_recipe",
+        "help": "Analyze text for methamphetamine synthesis instructions",
+    },
 }

--- a/jef/menu_cli.py
+++ b/jef/menu_cli.py
@@ -1,0 +1,275 @@
+import os
+import sys
+
+from jef import registry
+
+try:
+    import questionary
+
+    INTERACTIVE_MODE = True
+except ImportError:
+    INTERACTIVE_MODE = False
+
+from jef.cli_utils import Fore, Style
+
+
+def _get_scorers():
+    """Build scorer list from the registry (active scorers with CLI metadata only)."""
+    scorers = []
+    for meta in registry.list_active():
+        cli = meta.get("cli")
+        if cli is None:
+            continue
+        scorers.append(meta)
+    return scorers
+
+
+def list_files_and_folders(path):
+    items = os.listdir(path)
+    folders = [item for item in items if os.path.isdir(os.path.join(path, item))]
+    files = [item for item in items if os.path.isfile(os.path.join(path, item))]
+    return sorted(folders), sorted(files)
+
+
+def get_file_content(file_path):
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    except Exception as e:
+        print(f"{Fore.RED}Error reading file: {e}{Style.RESET_ALL}")
+        return None
+
+
+def print_menu_header():
+    """Print the JEF menu header."""
+    from jef.cli_utils import print_jef_header, print_section_header
+
+    print_jef_header()
+    print_section_header("Interactive File Browser & JEF Analyzer")
+    print(
+        f"{Fore.WHITE}Navigate through files and analyze them with JEF scoring algorithms{Style.RESET_ALL}\n"
+    )
+
+
+def _run_scorer(meta, file_content, prompt_fn):
+    """Run a scorer against file content, prompting for extra args if needed.
+
+    Args:
+        meta: The scorer's METADATA dict.
+        prompt_fn: A callable(label, choices) -> str|None for interactive prompts.
+    """
+    from jef.cli_utils import print_result, print_info, print_error
+
+    name = meta["name"]
+    cli = meta.get("cli", {})
+    kwargs = {}
+
+    for arg in cli.get("extra_args", []):
+        choices = arg.get("choices")
+        label = arg.get("help", "Choose an option")
+        value = prompt_fn(label, choices)
+        if value is None:
+            return  # user cancelled
+
+        attr = arg["flags"][-1].lstrip("-").replace("-", "_")
+        kwargs[attr] = value
+
+    print_info(f"Running {meta['display_name']} analysis...")
+    try:
+        result = registry.score(name, file_content, **kwargs)
+        print_result(result, meta["display_name"])
+    except Exception as e:
+        print_error(f"Analysis failed: {e}")
+
+
+def interactive_menu():
+    print_menu_header()
+    current_path = os.getcwd()
+
+    while True:
+        folders, files = list_files_and_folders(current_path)
+
+        choices = ["[..] Go up one directory"]
+        choices += [f"[FOLDER] {f}" for f in folders]
+        choices += [f"[FILE] {f}" for f in files]
+        choices.append("[EXIT] Quit JEF Menu")
+
+        print(
+            f"\n{Fore.CYAN}Current directory: {Fore.WHITE}{current_path}{Style.RESET_ALL}"
+        )
+
+        selection = questionary.select(
+            "Choose an option:",
+            choices=choices,
+            qmark=">",
+            pointer="->",
+        ).ask()
+
+        if selection is None:
+            break
+
+        if "[EXIT]" in selection:
+            print(f"{Fore.GREEN}Thank you for using JEF! Stay safe!{Style.RESET_ALL}")
+            break
+        elif "[..]" in selection:
+            current_path = os.path.dirname(current_path)
+        elif "[FOLDER]" in selection:
+            folder_name = selection.split("[FOLDER] ")[1]
+            current_path = os.path.join(current_path, folder_name)
+        elif "[FILE]" in selection:
+            file_name = selection.split("[FILE] ")[1]
+            selected_file_path = os.path.join(current_path, file_name)
+            file_content = get_file_content(selected_file_path)
+            if file_content is not None:
+                score_file_interactive(file_name, file_content)
+
+
+def score_file_interactive(file_name, file_content):
+    from jef.cli_utils import print_section_header
+
+    print_section_header(f"JEF Analysis for: {file_name}")
+
+    scorers = _get_scorers()
+    scorer_by_label = {m["display_name"]: m for m in scorers}
+    choices = list(scorer_by_label.keys()) + ["Back to file browser"]
+
+    print(
+        f"\n{Fore.WHITE}Choose analysis type for {Fore.YELLOW}{file_name}{Fore.WHITE}:{Style.RESET_ALL}"
+    )
+
+    scoring_choice = questionary.select(
+        "Select analysis:",
+        choices=choices,
+        qmark=">",
+        pointer="->",
+    ).ask()
+
+    if scoring_choice is None or scoring_choice == "Back to file browser":
+        return
+
+    meta = scorer_by_label.get(scoring_choice)
+    if meta is None:
+        return
+
+    def prompt_fn(label, choices):
+        if choices:
+            return questionary.select(label, choices=choices).ask()
+        return questionary.text(label).ask()
+
+    _run_scorer(meta, file_content, prompt_fn)
+    input(f"\n{Fore.CYAN}Press Enter to continue...{Style.RESET_ALL}")
+
+
+def fallback_menu():
+    print_menu_header()
+    from jef.cli_utils import print_error
+
+    current_path = os.getcwd()
+    while True:
+        folders, files = list_files_and_folders(current_path)
+        print(
+            f"\n{Fore.CYAN}Current directory: {Fore.WHITE}{current_path}{Style.RESET_ALL}"
+        )
+        print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
+        print(f"{Fore.YELLOW}0. [..] Go up{Style.RESET_ALL}")
+
+        for i, folder in enumerate(folders, 1):
+            print(f"{Fore.BLUE}{i}. [FOLDER] {folder}{Style.RESET_ALL}")
+
+        for i, file in enumerate(files, len(folders) + 1):
+            print(f"{Fore.GREEN}{i}. [FILE] {file}{Style.RESET_ALL}")
+
+        print(f"{Fore.RED}exit. Quit JEF Menu{Style.RESET_ALL}")
+        print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
+
+        try:
+            choice = input(f"{Fore.MAGENTA}> {Style.RESET_ALL}").strip()
+            if not choice:
+                continue
+            if choice.lower() == "exit":
+                print(
+                    f"{Fore.GREEN}Thank you for using JEF! Stay safe!{Style.RESET_ALL}"
+                )
+                break
+
+            choice_num = int(choice)
+            if choice_num == 0:
+                current_path = os.path.dirname(current_path)
+            elif 1 <= choice_num <= len(folders):
+                current_path = os.path.join(current_path, folders[choice_num - 1])
+            elif len(folders) < choice_num <= len(folders) + len(files):
+                file_name = files[choice_num - len(folders) - 1]
+                selected_file_path = os.path.join(current_path, file_name)
+                file_content = get_file_content(selected_file_path)
+                if file_content:
+                    score_file_fallback(file_name, file_content)
+            else:
+                print_error("Invalid selection.")
+        except (ValueError, IndexError):
+            print_error("Invalid input. Please enter a number.")
+        except (EOFError, KeyboardInterrupt):
+            print(f"\n{Fore.GREEN}Thank you for using JEF! Stay safe!{Style.RESET_ALL}")
+            break
+
+
+def score_file_fallback(file_name, file_content):
+    from jef.cli_utils import print_section_header, print_error
+
+    print_section_header(f"JEF Analysis for: {file_name}")
+
+    scorers = _get_scorers()
+    scorer_by_key = {}
+
+    print(f"{Fore.WHITE}Choose analysis type:")
+    for i, meta in enumerate(scorers, 1):
+        key = str(i)
+        scorer_by_key[key] = meta
+        print(f"  {Fore.CYAN}{key}. {meta['display_name']}{Style.RESET_ALL}")
+    print(f"  {Fore.YELLOW}back. Return to file browser{Style.RESET_ALL}")
+
+    choice = input(f"{Fore.MAGENTA}> {Style.RESET_ALL}").strip().lower()
+    if choice == "back" or not choice:
+        return
+
+    meta = scorer_by_key.get(choice)
+    if meta is None:
+        print_error("Invalid choice.")
+        return
+
+    def prompt_fn(label, choices):
+        if choices:
+            print(f"{Fore.WHITE}{label}:{Style.RESET_ALL}")
+            for j, c in enumerate(choices, 1):
+                print(f"  {Fore.CYAN}{j}. {c}{Style.RESET_ALL}")
+            ref_choice = input(f"{Fore.MAGENTA}> {Style.RESET_ALL}").strip()
+            try:
+                return choices[int(ref_choice) - 1]
+            except (ValueError, IndexError):
+                print_error("Invalid choice.")
+                return None
+        return input(f"{Fore.WHITE}{label}: {Style.RESET_ALL}")
+
+    _run_scorer(meta, file_content, prompt_fn)
+    input(f"\n{Fore.CYAN}Press Enter to continue...{Style.RESET_ALL}")
+
+
+def main():
+    is_non_interactive = not sys.stdout.isatty()
+
+    if INTERACTIVE_MODE and not is_non_interactive:
+        try:
+            interactive_menu()
+        except Exception as e:
+            print(f"{Fore.RED}Could not start interactive menu: {e}{Style.RESET_ALL}")
+            print(f"{Fore.YELLOW}Switching to fallback menu.{Style.RESET_ALL}")
+            fallback_menu()
+    else:
+        if not INTERACTIVE_MODE:
+            print(
+                f"{Fore.YELLOW}questionary library not found. Running in fallback mode.{Style.RESET_ALL}"
+            )
+        fallback_menu()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 
 
 [project.optional-dependencies]
+cli = ["questionary"]
 dev = ["pytest", "requests", "pytest-asyncio"]
 garak = ["garak>=0.13.3"]
 pyrit = ["pyrit>=0.11"]
@@ -24,6 +25,10 @@ Repository = "https://github.com/0din-ai/0din-JEF"
 [build-system]
 requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[project.scripts]
+jef = "jef.cli:main"
+jef-menu = "jef.menu_cli:main"
 
 [tool.setuptools_scm]
 # Version is derived from git tags automatically


### PR DESCRIPTION
Adds two CLIs for interacting with JEF — a standard `jef` command for scripting/automation and an interactive `jef-menu` for manual file browsing and analysis. Both CLIs are driven entirely by the scoring registry so new scorers appear automatically.

### Standard CLI (`jef`)

Registered as a `[project.scripts]` entry point. Provides subcommands for every active scorer plus `jef_score` and `jef_calculator` for the JEF formula:

```
jef score_meth_recipe "text to analyze"
jef copyright_score_hp "text" --ref page_one
jef jef_score --bv 0.8 --bm 0.6 --rt 0.4 --fd 0.7
```

Running `jef` with no arguments shows an enhanced help screen with all available commands.

### Interactive Menu (`jef-menu`)

Arrow-key driven file browser that lets you navigate the filesystem, select a file, and run any scorer on its contents. Falls back to a numbered-input mode when `questionary` isn't installed.

### Registry-driven design

Each active scorer's `METADATA` now includes a `cli` key describing its subcommand, help text, and any extra arguments:

```python
METADATA = {
    ...
    "cli": {
        "command": "score_meth_recipe",
        "help": "Analyze text for methamphetamine synthesis instructions",
    },
}
```

The CLI and menu build their scorer lists from `registry.list_active()` — no per-scorer switch statements. Adding a new scorer with a `cli` key is all that's needed to expose it in both interfaces. Deprecated scorers are excluded automatically.

### Other changes

- `questionary` moved to optional `[cli]` dependency group
- Sphinx docs page at `docs/source/cli.rst`
- Native ANSI color support in `cli_utils.py` (no `colorama` dependency)
- `except ImportError` instead of bare `except Exception` for questionary

Builds on #37 (includes all commits from that PR plus the registry refactor). Once merged, #37 can be closed.

Co-authored-by: KillAllTheHippies <1616421+KillAllTheHippies@users.noreply.github.com>