### PR TITLE
fix(integrations): make pyrit scorers compatible with pyrit 0.14+

### DIFF
--- a/jef/integrations/pyrit/scorers.py
+++ b/jef/integrations/pyrit/scorers.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 from typing import Optional
 
 from pyrit.models import MessagePiece, Score
-from pyrit.identifiers.scorer_identifier import ScorerIdentifier
+from pyrit.identifiers import ComponentIdentifier
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 
@@ -83,9 +83,9 @@ class _SubstanceScorer(FloatScaleScorer):
         self.show_matches = show_matches
         self._def = SUBSTANCE_SCORERS[self._scorer_key]
 
-    def _build_identifier(self) -> ScorerIdentifier:
+    def _build_identifier(self) -> ComponentIdentifier:
         return self._create_identifier(
-            scorer_specific_params={
+            params={
                 "show_matches": self.show_matches,
                 "harm_category": self._def.harm_category,
                 "substance": self._def.substance,
@@ -225,9 +225,9 @@ class JEFCopyrightScorer(FloatScaleScorer):
         self.min_ngram_size = min_ngram_size
         self.max_ngram_size = max_ngram_size
 
-    def _build_identifier(self) -> ScorerIdentifier:
+    def _build_identifier(self) -> ComponentIdentifier:
         return self._create_identifier(
-            scorer_specific_params={
+            params={
                 "harm_category": "copyright_violation",
                 "content_type": "harry_potter",
                 "ref": self.ref,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 [project.optional-dependencies]
 dev = ["pytest", "requests", "pytest-asyncio"]
 garak = ["garak>=0.13.3"]
-pyrit = ["pyrit>=0.11"]
+pyrit = ["pyrit>=0.13,<0.16"]
 
 [project.urls]
 Homepage = "https://0din.ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 [project.optional-dependencies]
 dev = ["pytest", "requests", "pytest-asyncio"]
 garak = ["garak>=0.13.3"]
-pyrit = ["pyrit>=0.13,<0.16"]
+pyrit = ["pyrit>=0.14,<0.15"]
 
 [project.urls]
 Homepage = "https://0din.ai"


### PR DESCRIPTION
pyrit 0.14 made two breaking changes that broke the JEF pyrit integration and aborted the **entire** test suite at collection:

- `pyrit.identifiers.scorer_identifier` was removed — `ScorerIdentifier` now lives in `pyrit.models`. The stale import failed collection (no tests ran).
- `Scorer._create_identifier`'s `scorer_specific_params` kwarg was renamed to `params`, raising `RuntimeError` at scoring time (16 tests).

Updates the import and both `_build_identifier` call sites, and caps `pyrit<0.16` (`pyrit.models.ScorerIdentifier` is deprecated for removal in 0.16 → migrate to `ComponentIdentifier` later). Verified: `pytest tests/integrations/pyrit/` → 98 passed under pyrit 0.14. Unblocks CI for all PRs.