### PR TITLE
fix(ci): install garak and pyrit extras in separate jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,26 +9,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv pip install --system '.[dev,garak,pyrit]'
-
-      - name: Run tests
-        run: pytest ./tests
+    uses: ./.github/workflows/test-suite.yml
 
   release:
     needs: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,44 @@
+name: Test Suite
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            extras: dev
+            pytest_args: ./tests --ignore=tests/integrations/garak --ignore=tests/integrations/pyrit
+          - name: garak
+            extras: dev,garak
+            pytest_args: tests/integrations/garak
+          - name: pyrit
+            extras: dev,pyrit
+            pytest_args: tests/integrations/pyrit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install --system ".[${{ matrix.extras }}]"
+
+      - name: Run tests
+        run: pytest ${{ matrix.pytest_args }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,51 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv pip install --system '.[dev,garak,pyrit]'
+        run: uv pip install --system '.[dev]'
 
       - name: Run tests
-        run: pytest ./tests
+        run: pytest ./tests --ignore=tests/integrations/garak --ignore=tests/integrations/pyrit
+
+  test-garak:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install --system '.[dev,garak]'
+
+      - name: Run tests
+        run: pytest tests/integrations/garak
+
+  test-pyrit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install --system '.[dev,pyrit]'
+
+      - name: Run tests
+        run: pytest tests/integrations/pyrit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     if: github.event_name == 'pull_request'
@@ -26,67 +29,4 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv pip install --system '.[dev]'
-
-      - name: Run tests
-        run: pytest ./tests --ignore=tests/integrations/garak --ignore=tests/integrations/pyrit
-
-  test-garak:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv pip install --system '.[dev,garak]'
-
-      - name: Run tests
-        run: pytest tests/integrations/garak
-
-  test-pyrit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv pip install --system '.[dev,pyrit]'
-
-      - name: Run tests
-        run: pytest tests/integrations/pyrit
+    uses: ./.github/workflows/test-suite.yml


### PR DESCRIPTION
`garak` (pins `datasets<4.0`) and `pyrit` 0.14 (requires `datasets>=4.8.0`) have mutually exclusive transitive dependencies and can no longer be resolved into a single environment, so `uv pip install '.[dev,garak,pyrit]'` fails to resolve. This breaks the `test` check on `main` and every open PR.

Split the single `test` job into three jobs with isolated installs:
- `test` (core): `.[dev]` — all tests except the two integration dirs
- `test-garak`: `.[dev,garak]` — `tests/integrations/garak`
- `test-pyrit`: `.[dev,pyrit]` — `tests/integrations/pyrit`

Verified locally that each extra resolves in isolation (`.[dev,garak]` → datasets 3.6.0, `.[dev,pyrit]` → datasets 5.0.0) and that the combined install reproduces the resolver failure.