### PR TITLE
ci: harden GitHub Actions workflows and add SOC 2 security controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for everything
+*                     @0din-ai/0din-developers
+
+# CI/CD and security-sensitive config require maintainer review
+/.github/             @0din-ai/0din-developers
+/pyproject.toml       @0din-ai/0din-developers
+/SECURITY.md          @0din-ai/0din-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot configuration.
+#
+# `uv` is a first-class Dependabot ecosystem distinct from `pip` (GitHub added
+# dedicated uv support: https://docs.github.com/en/code-security/dependabot/
+# working-with-dependabot/dependabot-options-reference#package-ecosystem-).
+# This repo is pyproject.toml-only, managed with uv, with no committed
+# requirements.txt/poetry.lock — `uv` is the correct ecosystem value here,
+# not `pip`.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
+
+  # Keeps the SHA-pinned `# vX.Y.Z` trailing comments in our workflows current
+  # by opening PRs that bump both the pin and its version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,19 +24,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.21.1
+        uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9.21.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions[bot]"
@@ -51,13 +51,13 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Upload to GitHub Release
         if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/publish-action@v9.21.1
+        uses: python-semantic-release/publish-action@1aa9f41fac5d531e6764e1991b536783337f3a56 # v9.21.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
@@ -71,17 +71,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.release.outputs.tag }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -103,7 +103,7 @@ jobs:
           sphinx-build -b html docs/source docs/build/html
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
+  sbom:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: write
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@d355de9a0cb79e0be2599696064231ee49aebb92 # main HEAD @ 2026-07-15
+    with:
+      sbom_name: 0din-jef
+
   docs:
     needs: release
     if: needs.release.outputs.released == 'true'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: test (${{ matrix.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -25,15 +27,15 @@ jobs:
             pytest_args: tests/integrations/pyrit
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,3 +34,28 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/test-suite.yml
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Audit dependencies for known vulnerabilities
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
+        with:
+          inputs: .
+
+  security-analysis:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: mozilla/ssdlc-actions/.github/workflows/code-security-analysis-public-repo.yml@d355de9a0cb79e0be2599696064231ee49aebb92 # main HEAD @ 2026-07-15

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,14 +11,16 @@ jobs:
   commitlint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
@@ -29,4 +31,6 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test-suite.yml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+JEF (`0din-jef` on PyPI) does not maintain long-term-support branches. Only the
+latest release published to [PyPI](https://pypi.org/project/0din-jef/) is
+supported with security fixes. If you're running an older version, please
+upgrade before reporting an issue.
+
+## Reporting a Vulnerability
+
+**Primary channel:** Please report security vulnerabilities using GitHub's
+[Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
+Go to this repository's **Security** tab and select **Report a vulnerability**.
+This creates a private advisory visible only to maintainers and lets us
+coordinate a fix with you directly.
+
+**Fallback channel:** If you're unable to use GitHub's reporting flow, email
+**0din@mozilla.com**. This address is PGP-capable if you need to encrypt your
+report.
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+## Response Expectations
+
+We aim to acknowledge new reports within a few business days. We'll work with
+you to understand and validate the issue, and to agree on a coordinated
+disclosure timeline before any public disclosure. Timelines vary with
+severity and complexity, but we'll keep you updated as we investigate and fix.
+
+## Scope
+
+JEF is a Python library for scoring and evaluating jailbreak attempts against
+LLM outputs — it is not a hosted service, and doesn't process or store user
+data on our infrastructure. Reports should generally concern the library's
+code (e.g. supply-chain issues in our packaging/release pipeline, or
+vulnerabilities in the scoring logic itself), not infrastructure we don't
+operate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 
 
 [project.optional-dependencies]
-dev = ["pytest", "requests", "pytest-asyncio"]
+dev = ["pytest", "requests>=2.33.0", "pytest-asyncio"]
 garak = ["garak>=0.13.3"]
 pyrit = ["pyrit>=0.14,<0.15"]
 


### PR DESCRIPTION
Pins all GitHub Actions to commit SHAs, adds SAST (Semgrep + zizmor) and dependency-vulnerability (pip-audit) scanning as merge gates, generates a CycloneDX SBOM on release, and adds Dependabot, CODEOWNERS, and a SECURITY.md vulnerability-disclosure policy.