### PR TITLE
chore: fix CODEOWNERS (SOC 2 sweep)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0din-ai/0din-developers
+* @athal7

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-# Default owner for everything
-*                     @0din-ai/0din-developers
-
-# CI/CD and security-sensitive config require maintainer review
-/.github/             @0din-ai/0din-developers
-/pyproject.toml       @0din-ai/0din-developers
-/SECURITY.md          @0din-ai/0din-developers
+* @0din-ai/0din-developers


### PR DESCRIPTION
Part of the 2026-07-20 SOC2 CODEOWNERS consistency sweep.

Replaces the granular per-path rules in `.github/CODEOWNERS` (separate entries for `*`, `/.github/`, `/pyproject.toml`, `/SECURITY.md` — all pointing at `@0din-ai/0din-developers`) with a single flat line `* @athal7`, designating @athal7 as the individual code owner for all files in this repo.

CODEOWNERS is used for automatic review-request purposes only. Required-review-from-code-owners is intentionally **not** enforced via branch protection (the two are decoupled), so this change has no effect on merge requirements.