### PR TITLE
fix(integrations): make pyrit scorers compatible with pyrit 1.x

### DIFF
--- a/jef/integrations/pyrit/scorers.py
+++ b/jef/integrations/pyrit/scorers.py
@@ -45,8 +45,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pyrit.models import MessagePiece, Score
-from pyrit.identifiers import ComponentIdentifier
+from pyrit.models import ComponentIdentifier, MessagePiece, Score
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 
@@ -76,6 +75,7 @@ class _SubstanceScorer(FloatScaleScorer):
 
     def __init__(
         self,
+        *,
         show_matches: bool = True,
         validator: Optional[ScorerPromptValidator] = None,
     ) -> None:
@@ -205,6 +205,7 @@ class JEFCopyrightScorer(FloatScaleScorer):
 
     def __init__(
         self,
+        *,
         ref: str = "chapter_one",
         min_ngram_size: int = 5,
         max_ngram_size: int = 7,

--- a/jef/integrations/pyrit/scorers.py
+++ b/jef/integrations/pyrit/scorers.py
@@ -45,7 +45,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pyrit.models import ComponentIdentifier, MessagePiece, Score
+from pyrit.models import MessagePiece, Score
+
+try:
+    # pyrit>=0.14 (current) exposes this from pyrit.models; older/edge
+    # releases may only expose it from the deprecated pyrit.identifiers path.
+    from pyrit.models import ComponentIdentifier
+except ImportError:  # pragma: no cover - defensive fallback
+    from pyrit.identifiers import ComponentIdentifier
+
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 [project.optional-dependencies]
 dev = ["pytest", "requests>=2.33.0", "pytest-asyncio"]
 garak = ["garak>=0.13.3"]
-pyrit = ["pyrit>=0.14,<0.15"]
+pyrit = ["pyrit>=0.14,<1.1"]
 
 [project.urls]
 Homepage = "https://0din.ai"


### PR DESCRIPTION
Fixes the failing `test (pyrit)` CI check blocking #67.

Widens the `pyrit` dependency range to `>=0.14,<1.1` (same change as #67) and fixes two breaking changes introduced in pyrit 1.x that the wider range exposes:
- `pyrit.identifiers` was removed; `ComponentIdentifier` now lives in `pyrit.models`.
- `Scorer.__init_subclass__` now enforces keyword-only `__init__` params on all `Scorer` subclasses. Adds `*,` after `self` in `_SubstanceScorer` and `JEFCopyrightScorer`; call sites already use keyword args.

Verified against pyrit==1.0.1: `tests/integrations/pyrit` (98 passed), rest of suite excluding garak (211 passed, 6 subtests), garak unaffected (72 passed).

Closes #67