### PR TITLE
fix(release): restore PyPI publishing after psr v10 upgrade

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,13 @@ jobs:
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
           commit: "false"  # setuptools-scm derives version from tags, no release commits needed
 
+      - name: Fetch release tag
+        if: steps.release.outputs.released == 'true'
+        # Python Semantic Release pushes the new tag via the GitHub API; the
+        # step 4 checkout predates it, so setuptools-scm can't see it yet and
+        # would derive a `+local` version that PyPI rejects. Pull it down.
+        run: git fetch origin tag ${{ steps.release.outputs.tag }}
+
       - name: Build package
         if: steps.release.outputs.released == 'true'
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ version_toml = []
 version_variables = []
 tag_format = "v{version}"
 commit_parser = "conventional"
+allow_zero_version = true  # Stay on 0.x until we deliberately choose to graduate to 1.0.0
 major_on_zero = false  # Don't bump to 1.0.0 on breaking changes while < 1.0
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
Restores PyPI publishing, broken since the psr 9.21.1→10.6.1 bump (#63): its new `allow_zero_version=false` default forced an unintended jump to v1.0.0, and the build step runs before the new tag is fetched locally, so setuptools-scm emits a `+local` version PyPI rejects. Sets `allow_zero_version = true` and fetches the release tag before building.