### PR TITLE
fix(release): build via PSR build_command instead of racing tag fetch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,19 +42,8 @@ jobs:
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
           commit: "false"  # setuptools-scm derives version from tags, no release commits needed
-
-      - name: Fetch release tag
-        if: steps.release.outputs.released == 'true'
-        # Python Semantic Release pushes the new tag via the GitHub API; the
-        # step 4 checkout predates it, so setuptools-scm can't see it yet and
-        # would derive a `+local` version that PyPI rejects. Pull it down.
-        run: git fetch origin tag ${{ steps.release.outputs.tag }}
-
-      - name: Build package
-        if: steps.release.outputs.released == 'true'
-        run: |
-          python -m pip install --upgrade pip build
-          python -m build
+          # build_command in pyproject.toml builds dist/ in-process, using
+          # NEW_VERSION, before the tag exists — see comment there.
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ tag_format = "v{version}"
 commit_parser = "conventional"
 allow_zero_version = true  # Stay on 0.x until we deliberately choose to graduate to 1.0.0
 major_on_zero = false  # Don't bump to 1.0.0 on breaking changes while < 1.0
+# Build dist/ ourselves, in-process, right after PSR computes the version and
+# before it tags. setuptools-scm can't see a tag PSR hasn't created yet, so we
+# pin the version explicitly via PSR's own NEW_VERSION instead of racing a
+# `git fetch` against tag creation.
+build_command = "python -m pip install --upgrade build && SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION python -m build"
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"


### PR DESCRIPTION
#76's tag-fetch fix didn't survive production — the merge itself republished as `0.8.3.dev0+local` and PyPI rejected it again. Switches to python-semantic-release's documented `build_command` hook: it runs before any tag exists and exports `NEW_VERSION`, so `setuptools-scm` is pinned via `SETUPTOOLS_SCM_PRETEND_VERSION` instead of depending on git tag/fetch timing. Verified end-to-end by running the real PSR binary locally (no push/tag side effects) — it produced a clean 0.8.2 wheel that passes `twine check`. Drops the now-redundant fetch/build steps from `publish.yml`.